### PR TITLE
fix: correct artifactId for sast-link-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>fun.feellmoose</groupId>
-            <artifactId>sast-link-SDK</artifactId>
+            <artifactId>sast-link-sdk</artifactId>
             <version>0.1.2</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
> [ERROR] Could not resolve dependencies for project com.qingyou:sast-evento-lark:jar:0.0.1-SNAPSHOT: 
>     fun.feellmoose:sast-link-SDK:jar:0.1.2 was not found in https://repo.maven.apache.org/maven2 during a previous attempt. 

需要与 Maven Central 仓库保持一致的大小写规则，否则无法从中央库正确下载